### PR TITLE
Add persistent dark mode theme

### DIFF
--- a/level-up-irl/App.tsx
+++ b/level-up-irl/App.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, DefaultTheme, DarkTheme as NavigationDarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { DarkModeProvider } from './context/DarkModeContext';
+import { DarkModeProvider, useDarkMode } from './context/DarkModeContext';
+import { darkTheme, lightTheme } from './utils/theme';
 
 import WelcomeScreen from './screens/WelcomeScreen';
 import HomeScreen from './screens/HomeScreen';
@@ -16,13 +17,12 @@ const Tab = createBottomTabNavigator();
 
 const MainTabs = () => {
   return (
-    <DarkModeProvider>
-      <Tab.Navigator
-        screenOptions={{
-          tabBarActiveTintColor: '#4CAF50',
-          tabBarInactiveTintColor: 'gray',
-        }}
-      >
+    <Tab.Navigator
+      screenOptions={{
+        tabBarActiveTintColor: '#4CAF50',
+        tabBarInactiveTintColor: 'gray',
+      }}
+    >
         <Tab.Screen
           name="Home"
           component={HomeScreen}
@@ -47,8 +47,24 @@ const MainTabs = () => {
             headerShown: false,
           }}
         />
-      </Tab.Navigator>
-    </DarkModeProvider>
+    </Tab.Navigator>
+  );
+};
+
+
+const AppContent: React.FC<{ isFirstTime: boolean }> = ({ isFirstTime }) => {
+  const { isDarkMode } = useDarkMode();
+  const navTheme = isDarkMode ? NavigationDarkTheme : DefaultTheme;
+
+  return (
+    <NavigationContainer theme={navTheme}>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        {isFirstTime ? (
+          <Stack.Screen name="Welcome" component={WelcomeScreen} />
+        ) : null}
+        <Stack.Screen name="Home" component={MainTabs} />
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 };
 
@@ -74,14 +90,9 @@ const App: React.FC = () => {
   }
 
   return (
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        {isFirstTime ? (
-          <Stack.Screen name="Welcome" component={WelcomeScreen} />
-        ) : null}
-        <Stack.Screen name="Home" component={MainTabs} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <DarkModeProvider>
+      <AppContent isFirstTime={isFirstTime} />
+    </DarkModeProvider>
   );
 };
 

--- a/level-up-irl/components/TaskItem.tsx
+++ b/level-up-irl/components/TaskItem.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useDarkMode } from '../context/DarkModeContext';
+import { darkTheme, lightTheme } from '../utils/theme';
 
 interface TaskItemProps {
   name: string;
@@ -9,6 +11,10 @@ interface TaskItemProps {
 }
 
 const TaskItem: React.FC<TaskItemProps> = ({ name, xp, completed, onToggle }) => {
+  const { isDarkMode } = useDarkMode();
+  const theme = isDarkMode ? darkTheme : lightTheme;
+  const styles = getStyles(theme);
+
   return (
     <TouchableOpacity style={[styles.task, completed && styles.completed]} onPress={onToggle}>
       <Text style={styles.taskText}>{name}</Text>
@@ -17,26 +23,28 @@ const TaskItem: React.FC<TaskItemProps> = ({ name, xp, completed, onToggle }) =>
   );
 };
 
-const styles = StyleSheet.create({
-  task: {
-    padding: 15,
-    borderRadius: 10,
-    marginVertical: 8,
-    backgroundColor: '#f0f0f0',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  completed: {
-    backgroundColor: '#c4f0c4',
-  },
-  taskText: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  xpText: {
-    fontSize: 16,
-    color: '#666',
-  },
-});
+const getStyles = (theme: typeof lightTheme) =>
+  StyleSheet.create({
+    task: {
+      padding: 15,
+      borderRadius: 10,
+      marginVertical: 8,
+      backgroundColor: theme.card,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    completed: {
+      backgroundColor: theme.success,
+    },
+    taskText: {
+      fontSize: 16,
+      fontWeight: '500',
+      color: theme.text,
+    },
+    xpText: {
+      fontSize: 16,
+      color: theme.text,
+    },
+  });
 
 export default TaskItem;

--- a/level-up-irl/context/DarkModeContext.tsx
+++ b/level-up-irl/context/DarkModeContext.tsx
@@ -1,5 +1,12 @@
 // DarkModeContext.tsx
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 interface DarkModeContextProps {
   isDarkMode: boolean;
@@ -11,8 +18,22 @@ const DarkModeContext = createContext<DarkModeContextProps | undefined>(undefine
 export const DarkModeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
-  const toggleDarkMode = () => {
-    setIsDarkMode((prev) => !prev);
+  useEffect(() => {
+    const loadPreference = async () => {
+      const stored = await AsyncStorage.getItem('darkMode');
+      if (stored !== null) {
+        setIsDarkMode(stored === 'true');
+      }
+    };
+    loadPreference();
+  }, []);
+
+  const toggleDarkMode = async () => {
+    setIsDarkMode((prev) => {
+      const next = !prev;
+      AsyncStorage.setItem('darkMode', next.toString());
+      return next;
+    });
   };
 
   return (

--- a/level-up-irl/screens/HomeScreen.tsx
+++ b/level-up-irl/screens/HomeScreen.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { useDarkMode } from '../context/DarkModeContext';
+import { darkTheme, lightTheme } from '../utils/theme';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import TaskItem from '../components/TaskItem';
 
@@ -23,6 +25,7 @@ const HomeScreen: React.FC = () => {
   const [name, setName] = useState<string | null>(null);
   const [tasks, setTasks] = useState<Task[]>(initialTasks);
   const [xp, setXp] = useState<number>(0);
+  const { isDarkMode } = useDarkMode();
 
   useEffect(() => {
     const loadData = async () => {
@@ -67,6 +70,9 @@ const HomeScreen: React.FC = () => {
     }
   };
 
+  const theme = isDarkMode ? darkTheme : lightTheme;
+  const styles = getStyles(theme);
+
   return (
     <View style={styles.container}>
       <Text style={styles.greeting}>
@@ -98,44 +104,48 @@ const HomeScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 20,
-  },
-  greeting: {
-    fontSize: 22,
-    fontWeight: '600',
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  xpDisplay: {
-    fontSize: 18,
-    fontWeight: '500',
-    marginBottom: 20,
-    textAlign: 'center',
-    color: '#4CAF50',
-  },
-  progressWrapper: {
-    marginBottom: 20,
-  },
-  levelText: {
-    fontSize: 16,
-    fontWeight: '500',
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  progressBar: {
-    height: 20,
-    width: '100%',
-    backgroundColor: '#eee',
-    borderRadius: 10,
-    overflow: 'hidden',
-  },
-  progressFill: {
-    height: '100%',
-    backgroundColor: '#4CAF50',
-  },
-});
+const getStyles = (theme: typeof lightTheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      padding: 20,
+      backgroundColor: theme.background,
+    },
+    greeting: {
+      fontSize: 22,
+      fontWeight: '600',
+      marginBottom: 10,
+      textAlign: 'center',
+      color: theme.text,
+    },
+    xpDisplay: {
+      fontSize: 18,
+      fontWeight: '500',
+      marginBottom: 20,
+      textAlign: 'center',
+      color: theme.accent,
+    },
+    progressWrapper: {
+      marginBottom: 20,
+    },
+    levelText: {
+      fontSize: 16,
+      fontWeight: '500',
+      marginBottom: 10,
+      textAlign: 'center',
+      color: theme.text,
+    },
+    progressBar: {
+      height: 20,
+      width: '100%',
+      backgroundColor: theme.card,
+      borderRadius: 10,
+      overflow: 'hidden',
+    },
+    progressFill: {
+      height: '100%',
+      backgroundColor: theme.accent,
+    },
+  });
 
 export default HomeScreen;

--- a/level-up-irl/screens/ProfileScreen.tsx
+++ b/level-up-irl/screens/ProfileScreen.tsx
@@ -1,31 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Switch, TextInput, Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useDarkMode } from '../context/DarkModeContext';
+import { darkTheme, lightTheme } from '../utils/theme';
 
 const ProfileScreen: React.FC = () => {
-  const [darkMode, setDarkMode] = useState(false);
+  const { isDarkMode, toggleDarkMode } = useDarkMode();
   const [name, setName] = useState('');
 
   useEffect(() => {
     const loadSettings = async () => {
-      const storedDark = await AsyncStorage.getItem('darkMode');
       const storedName = await AsyncStorage.getItem('heroName');
-      if (storedDark !== null) setDarkMode(storedDark === 'true');
       if (storedName) setName(storedName);
     };
     loadSettings();
   }, []);
 
-  const toggleDarkMode = async () => {
-    const newValue = !darkMode;
-    setDarkMode(newValue);
-    await AsyncStorage.setItem('darkMode', newValue.toString());
-  };
-
   const saveName = async () => {
     await AsyncStorage.setItem('heroName', name);
     Alert.alert('Saved', 'Your hero name has been updated!');
   };
+
+  const theme = isDarkMode ? darkTheme : lightTheme;
+  const styles = getStyles(theme);
 
   return (
     <View style={styles.container}>
@@ -33,7 +30,7 @@ const ProfileScreen: React.FC = () => {
 
       <View style={styles.settingRow}>
         <Text style={styles.label}>Dark Mode</Text>
-        <Switch value={darkMode} onValueChange={toggleDarkMode} />
+        <Switch value={isDarkMode} onValueChange={toggleDarkMode} />
       </View>
 
       <View style={styles.settingRowColumn}>
@@ -50,37 +47,42 @@ const ProfileScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 20,
-  },
-  heading: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  settingRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 20,
-  },
-  settingRowColumn: {
-    marginBottom: 20,
-  },
-  label: {
-    fontSize: 18,
-    marginBottom: 8,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: 8,
-    padding: 10,
-    fontSize: 16,
-  },
-});
+const getStyles = (theme: typeof lightTheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      padding: 20,
+      backgroundColor: theme.background,
+    },
+    heading: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      marginBottom: 20,
+      textAlign: 'center',
+      color: theme.text,
+    },
+    settingRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 20,
+    },
+    settingRowColumn: {
+      marginBottom: 20,
+    },
+    label: {
+      fontSize: 18,
+      marginBottom: 8,
+      color: theme.text,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.border,
+      borderRadius: 8,
+      padding: 10,
+      fontSize: 16,
+      color: theme.text,
+    },
+  });
 
 export default ProfileScreen;

--- a/level-up-irl/screens/StreaksScreen.tsx
+++ b/level-up-irl/screens/StreaksScreen.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useDarkMode } from '../context/DarkModeContext';
+import { darkTheme, lightTheme } from '../utils/theme';
 
 const StreaksScreen: React.FC = () => {
   const [streak, setStreak] = useState(0);
   const [lastDate, setLastDate] = useState('');
+  const { isDarkMode } = useDarkMode();
 
   useEffect(() => {
     const checkStreak = async () => {
@@ -42,6 +45,9 @@ const StreaksScreen: React.FC = () => {
     checkStreak();
   }, []);
 
+  const theme = isDarkMode ? darkTheme : lightTheme;
+  const styles = getStyles(theme);
+
   return (
     <View style={styles.container}>
       <Text style={styles.heading}>🔥 Your Streak</Text>
@@ -51,27 +57,30 @@ const StreaksScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-  },
-  heading: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 10,
-  },
-  text: {
-    fontSize: 18,
-    color: '#4CAF50',
-    marginBottom: 4,
-  },
-  subtext: {
-    fontSize: 14,
-    color: '#777',
-  },
-});
+const getStyles = (theme: typeof lightTheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+      backgroundColor: theme.background,
+    },
+    heading: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      marginBottom: 10,
+      color: theme.text,
+    },
+    text: {
+      fontSize: 18,
+      color: theme.accent,
+      marginBottom: 4,
+    },
+    subtext: {
+      fontSize: 14,
+      color: theme.text,
+    },
+  });
 
 export default StreaksScreen;

--- a/level-up-irl/screens/WelcomeScreen.tsx
+++ b/level-up-irl/screens/WelcomeScreen.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { useDarkMode } from '../context/DarkModeContext';
+import { darkTheme, lightTheme } from '../utils/theme';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../types';
@@ -10,6 +12,7 @@ type WelcomeScreenNavigationProp = NativeStackNavigationProp<RootStackParamList,
 const WelcomeScreen: React.FC = () => {
   const [name, setName] = useState('');
   const navigation = useNavigation<WelcomeScreenNavigationProp>();
+  const { isDarkMode } = useDarkMode();
 
   const handleStart = async () => {
     if (!name.trim()) {
@@ -24,6 +27,9 @@ const WelcomeScreen: React.FC = () => {
       Alert.alert('Failed to save your name. Please try again.');
     }
   };
+
+  const theme = isDarkMode ? darkTheme : lightTheme;
+  const styles = getStyles(theme);
 
   return (
     <View style={styles.container}>
@@ -40,31 +46,36 @@ const WelcomeScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-  },
-  title: {
-    fontSize: 26,
-    fontWeight: 'bold',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  label: {
-    fontSize: 18,
-    marginBottom: 10,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: '#aaa',
-    padding: 10,
-    borderRadius: 8,
-    width: '100%',
-    marginBottom: 20,
-  },
-});
+const getStyles = (theme: typeof lightTheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+      backgroundColor: theme.background,
+    },
+    title: {
+      fontSize: 26,
+      fontWeight: 'bold',
+      marginBottom: 20,
+      textAlign: 'center',
+      color: theme.text,
+    },
+    label: {
+      fontSize: 18,
+      marginBottom: 10,
+      color: theme.text,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.border,
+      padding: 10,
+      borderRadius: 8,
+      width: '100%',
+      marginBottom: 20,
+      color: theme.text,
+    },
+  });
 
 export default WelcomeScreen;

--- a/level-up-irl/utils/theme.ts
+++ b/level-up-irl/utils/theme.ts
@@ -15,3 +15,4 @@ export const darkTheme = {
   success: '#2e7d32',
   border: '#333333',
 };
+


### PR DESCRIPTION
## Summary
- make dark mode preference persist with `AsyncStorage`
- wrap app navigation in `DarkModeProvider`
- apply themed styles across screens and components

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aa6c448c083328468814ba326101b